### PR TITLE
Add more ways to update the properties of `Colour` object

### DIFF
--- a/Elements.js
+++ b/Elements.js
@@ -25,7 +25,7 @@ const Elements = {};
   Elements.Colour = function (type, ...data) {
     if (!new.target) throw {
       name: 'SyntaxError',
-      message: `Elements.Colour() must be called with new`
+      message: 'Elements.Colour() must be called with new'
     };
     if (typeof type === 'string') {
       if (!['rgb', 'rgba', 'hsl', 'hsla', 'cmy', 'cmya'].includes(type.toLowerCase())) throw {
@@ -44,8 +44,7 @@ const Elements = {};
   Reflect.defineProperty(Elements.Colour.prototype, 'rgb', {
     get() { return [this.r, this.g, this.b] },
     set(...data) { this.rgba = [data, this.a] },
-    configurable: true,
-    enumerable: false
+    configurable: true, enumerable: false
   });
   
   Reflect.defineProperty(Elements.Colour.prototype, 'rgba', {
@@ -57,8 +56,25 @@ const Elements = {};
       this.b = data[2]===undefined ? this.b : data[2];
       this.a = data[3]===undefined ? this.a : data[3];
     },
-    configurable: true,
-    enumerable: false
+    configurable: true, enumerable: false
+  });
+  
+  Reflect.defineProperty(Elements.Colour.prototype, 'h', {
+    get() { return this.hsl[0] },
+    set(hue) { let b4 = this.hsla; this.hsla = [hue, b4[1], b4[2], b4[3]] },
+    configurable: true, enumerable: false
+  });
+  
+  Reflect.defineProperty(Elements.Colour.prototype, 's', {
+    get() { return this.hsl[1] },
+    set(saturation) { let b4 = this.hsla; this.hsla = [b4[0], saturation, b4[2], b4[3]] },
+    configurable: true, enumerable: false
+  });
+  
+  Reflect.defineProperty(Elements.Colour.prototype, 'l', {
+    get() { return this.hsl[2] },
+    set(lightness) { let b4 = this.hsla; this.hsla = [b4[0], b4[1], lightness, b4[3]] },
+    configurable: true, enumerable: false
   });
   
   Reflect.defineProperty(Elements.Colour.prototype, 'hsl', {
@@ -66,8 +82,7 @@ const Elements = {};
     set(..._data) {
       let data = [...Array(3)].map((e, i)=>_data[i]);
       this.hsla = [...data, this.a] },
-    configurable: true,
-    enumerable: false
+    configurable: true, enumerable: false
   });
   
   Reflect.defineProperty(Elements.Colour.prototype, 'hsla', {
@@ -84,15 +99,31 @@ const Elements = {};
       this.b = data[2];
       this.a = data[3]===undefined ? this.a : data[3];
     },
-    configurable: true,
-    enumerable: false
+    configurable: true, enumerable: false
+  });
+  
+  Reflect.defineProperty(Elements.Colour.prototype, 'c', {
+    get() { return this.cmy[0] },
+    set(cyan) { let b4 = this.cmya; this.cmya = [cyan, b4[1], b4[2], b4[3]] },
+    configurable: true, enumerable: false
+  });
+  
+  Reflect.defineProperty(Elements.Colour.prototype, 'm', {
+    get() { return this.cmy[1] },
+    set(magenta) { let b4 = this.cmya; this.cmya = [b4[0], magenta, b4[2], b4[3]] },
+    configurable: true, enumerable: false
+  });
+  
+  Reflect.defineProperty(Elements.Colour.prototype, 'y', {
+    get() { return this.cmy[2] },
+    set(yellow) { let b4 = this.cmya; this.cmya = [b4[0], b4[1], yellow, b4[3]] },
+    configurable: true, enumerable: false
   });
   
   Reflect.defineProperty(Elements.Colour.prototype, 'cmy', {
     get() { return [255-this.r, 255-this.g, 255-this.b] },
     set(...data) { this.cmya = [data, this.a] },
-    configurable: true,
-    enumerable: false
+    configurable: true, enumerable: false
   });
   
   Reflect.defineProperty(Elements.Colour.prototype, 'cmya', {
@@ -104,8 +135,7 @@ const Elements = {};
       this.b = data[2]===undefined ? this.b : 255-data[2];
       this.a = data[3]===undefined ? this.a : data[3];
     },
-    configurable: true,
-    enumerable: false
+    configurable: true, enumerable: false
   });
   
   // rgb2hsl() and hsl2rgb() adapted from Kamil Kiełczewski's answer from StackOverflow
@@ -115,7 +145,7 @@ const Elements = {};
   Elements.Colour.hsl2rgb = function (h=0, s=1, l=0.5) {
     let a = s * Math.min(l, 1-l);
     let f = (n, k=(n+(h+360)/30)%12) => l - a * Math.max(Math.min(k-3, 9-k, 1), -1);                 
-    return [Math.floor(255*f(0)), Math.floor(255*f(8)), Math.floor(255*f(4))]
+    return [255*f(0), 255*f(8), 255*f(4)]
   }
   
   // r[0-255] g[0-255] b[0-255] -> h[0-360] s[0-1] l[0-1]
@@ -126,14 +156,8 @@ const Elements = {};
     return [60*(h<0?h+6:h), f ? c/f : 0, (v+v-c)/2]
   }
   
-  // c[0-255] m[0-255] y[0-255] -> r[0-255] g[0-255] b[0-255]
-  Elements.Colour.cmy2rgb = (c=0, m=0, y=0) => [
-    Elements.Math.clamp(255-c, 0, 255),
-    Elements.Math.clamp(255-m, 0, 255),
-    Elements.Math.clamp(255-y, 0, 255)
-  ];
-  
-  // r[0-255] g[0-255] b[0-255] -> c[0-255] m[0-255] y[0-255]
+  // c[0-255] m[0-255] y[0-255] <-> r[0-255] g[0-255] b[0-255]
+  Elements.Colour.cmy2rgb = (c=0, m=0, y=0) => [ 255-c, 255-m, 255-y ];
   Elements.Colour.rgb2cmy = Elements.Colour.cmy2rgb;
   
   Elements.Colour.install = function (global) {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,13 @@
 Elements.install(this)
 
-let col = new Colour('cmy', 255, 75, 100)
-col.hsl = [undefined, 0.5, 0.5]
-console.log(col.rgb)
+let teal = new Colour('cmy', 255, 75, 100)
+teal.hsl = [undefined, 0.5, 0.5]
+console.log('teal', teal.hsl)
 // a nice looking teal colour tbh
-document.body.style.backgroundColor = `rgba(${col.r}, ${col.g}, ${col.b}, ${col.a})`
+document.body.style.backgroundColor = `rgba(${teal.r}, ${teal.g}, ${teal.b}, ${teal.a})`
+
+let peach = new Colour(teal)
+peach.r = 255
+console.log('peach', peach.hsl)
+// a cute peach colour lmao
+document.body.style.backgroundColor = `rgba(${peach.r}, ${peach.g}, ${peach.b}, ${peach.a})`


### PR DESCRIPTION
Test.js
- Renamed `col` to `teal`
- Added `peach` - teal but with full red


Elements.js
- Added `.h`, `.s`, `.l`, `.c`, `.m` and `.y`
- Cleaned up the `configurable` and `enumerable` property... properties? of `Colour` object